### PR TITLE
Make sure the obj files from workers are not stripped

### DIFF
--- a/shared/helper.py
+++ b/shared/helper.py
@@ -104,6 +104,10 @@ def linuxOutput(buildFolder):
     # strip sharedobjects
     import glob
     sharedObjects = glob.glob("**/*.so", recursive=True)
+
+    # obj files inside the workers should not be removed as workers like "python"
+    # come with objects necessary for the worker to work.
+    sharedObjects = [obj for obj in sharedObjects if "workers" not in obj]
     printReturnOutput(["strip", "--strip-unneeded"] + sharedObjects)
 
     chmodFolderAndFiles(os.path.join(buildFolder, "usr"))


### PR DESCRIPTION
`strip` now fails to strip files in the new builds of core-tools. It fails with --

```
strip:usr/lib/azure-functions-core-tools/workers/python/3.6/OSX/X64/google/protobuf/internal/_api_implementation.cpython-36m-darwin.so: File format not recognized
strip:usr/lib/azure-functions-core-tools/workers/python/3.6/OSX/X64/google/protobuf/pyext/_message.cpython-36m-darwin.so: File format not recognized
strip:usr/lib/azure-functions-core-tools/workers/python/3.6/OSX/X64/grpc/_cython/cygrpc.cpython-36m-darwin.so: File format not recognized
strip:usr/lib/azure-functions-core-tools/workers/python/3.7/OSX/X64/google/protobuf/internal/_api_implementation.cpython-37m-darwin.so: File format not recognized
strip:usr/lib/azure-functions-core-tools/workers/python/3.7/OSX/X64/google/protobuf/pyext/_message.cpython-37m-darwin.so: File format not recognized
strip:usr/lib/azure-functions-core-tools/workers/python/3.7/OSX/X64/grpc/_cython/cygrpc.cpython-37m-darwin.so: File format not recognized
strip:usr/lib/azure-functions-core-tools/workers/python/3.6/OSX/X64/google/protobuf/internal/_api_implementation.cpython-36m-darwin.so: File format not recognized
strip:usr/lib/azure-functions-core-tools/workers/python/3.6/OSX/X64/google/protobuf/pyext/_message.cpython-36m-darwin.so: File format not recognized
strip:usr/lib/azure-functions-core-tools/workers/python/3.6/OSX/X64/grpc/_cython/cygrpc.cpython-36m-darwin.so: File format not recognized
strip:usr/lib/azure-functions-core-tools/workers/python/3.7/OSX/X64/google/protobuf/internal/_api_implementation.cpython-37m-darwin.so: File format not recognized
strip:usr/lib/azure-functions-core-tools/workers/python/3.7/OSX/X64/google/protobuf/pyext/_message.cpython-37m-darwin.so: File format not recognized
strip:usr/lib/azure-functions-core-tools/workers/python/3.7/OSX/X64/grpc/_cython/cygrpc.cpython-37m-darwin.so: File format not recognized
```

To repro, `python driver.py 2.7.1846`


I did not look too far, but seems like this might be due to the mismatch of the build environment vs strip environment. Either way, I figured we shouldn't be stripping objects from the workers. As in, the above files all of them, should not be stripped.